### PR TITLE
Release 1.11.1: drop axios mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @narisolutions/api-client
 
-A lightweight, TypeScript-first HTTP client with Firebase JWT authentication. Designed as a smaller-footprint alternative to [axios](https://www.npmjs.com/package/axios), focused on the most common API request scenarios. Additional clients (e.g. GraphQL) are planned under separate subpath exports.
+A lightweight, TypeScript-first HTTP client with Firebase JWT authentication. Small bundle footprint, focused on the most common API request scenarios. Additional clients (e.g. GraphQL) are planned under separate subpath exports.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@narisolutions/api-client",
     "private": false,
-    "version": "1.11.0",
+    "version": "1.11.1",
     "type": "module",
     "description": "Minimal library for handling API requests.",
     "author": "Nari Solutions LLC",


### PR DESCRIPTION
## Summary

Doc-only patch release: remove the axios comparison from the README intro.

## Test plan
- [x] Tests pass on develop.
- [ ] Release workflow publishes to npm on `release-1.11.1` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)